### PR TITLE
Windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ However, we have introduced several tools to make our life easier:
 
 ### Building via Taskfile
 
-The recommended way to build our project on Windows (only when running via git bash) or Linux is via our project's [Taskfile](https://taskfile.dev/).
+The recommended way to build our project on Windows or Linux is via our project's [Taskfile](https://taskfile.dev/).
 Then you can build and run the project with a single command - `task run`.
 
 Alternatively, if you just want to build the project you can run `task build` to build the sourcecode to `./bin`.
@@ -31,16 +31,24 @@ Note that this cannot handle folders containing spaces!
 
 Provide them in the following way: `task run OUTPUT_FOLDER='my-output-folder' CFLAGS='-ansi'`
 
+Note that running `task build/run` under windows requires Git Bash since we need some of the cli tools installed with it (e.g. sed, find, xargs).
+Since time was of the essence we opted to reuse the `build-shell` task instead of writing a new build task for windows in CMD/Powershell.
+But even though the current version requires Git Bash the task works on Git Bash, PowerShell as well as CMD.
+
 #### Open Taskfile Todos
 
-- TODO: If you're really feeling powershell and/or cmd try scripting the build-windows task so it works from CMD and Powershell and GitBash (currently only works with Git Bash)
 - TODO (GM): Find someone with a MacOs (Samu?) to test build-linux!
 - TODO (GM): Implement task for unit tests
+- TODO: If you're feeling fancy implement a PS-only version of compile.ps1 and use it in build-windows instead of the current version.
 
-### Building via Bash Script
+### Building via Script
 
 Alternatively, if you have access to Bash you can compile the whole project by running `./compile.sh` which also builds to `./bin`.
 Afterwards execute `./bin/minesweeper.out` to run the program.
+
+There is also a build script for powershell - `compile.ps1` - but that leverages Taskfile and Git Bash,
+so if you don't have both of these installed, this won't work for you.
+And if you do... why not just use our Taskfile?
 
 ### Building by hand
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Provide them in the following way: `task run OUTPUT_FOLDER='my-output-folder' CF
 
 Note that running `task build/run` under windows requires Git Bash since we need some of the cli tools installed with it (e.g. sed, find, xargs).
 Since time was of the essence we opted to reuse the `build-shell` task instead of writing a new build task for windows in CMD/Powershell.
-But even though the current version requires Git Bash the task works on Git Bash, PowerShell as well as CMD.
+However, even though the current version requires Git Bash the task works on Git Bash, PowerShell, as well as CMD.
 
 #### Open Taskfile Todos
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ This also creates the executable `./bin/minesweeper.out`, which you can use to r
 
 Optionally you can pass the following parameters to `task build` or `task run`:
 
-- OUTPUT_FOLDER: The folder to build to. Falls back to the $OUTPUT_FOLDER environment variable or 'bin' if no environment variable is set.
+- `OUTPUT_FOLDER`: The folder to build to. Falls back to the `$OUTPUT_FOLDER` environment variable or `bin` if no environment variable is set.
 Note that this cannot handle folders containing spaces!
-- CFLAGS: The compiler flags to use. Falls back to the $CFLAGS environment variable or '-Wall -Wextra -Werror -ansi -pedantic' if no environment variable is set.
+- `CFLAGS`: The compiler flags to use. Falls back to the `$CFLAGS` environment variable or `-Wall -Wextra -Werror -ansi -pedantic` if no environment variable is set.
 
 Provide them in the following way: `task run OUTPUT_FOLDER='my-output-folder' CFLAGS='-ansi'`
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ However, we have introduced several tools to make our life easier:
 
 ### Building via Taskfile
 
-The recommended way to build our project on Windows or Linux is via our project's [Taskfile](https://taskfile.dev/).
+The recommended way to build our project on Windows (only when running via git bash) or Linux is via our project's [Taskfile](https://taskfile.dev/).
 Then you can build and run the project with a single command - `task run`.
 
 Alternatively, if you just want to build the project you can run `task build` to build the sourcecode to `./bin`.
@@ -33,10 +33,9 @@ Provide them in the following way: `task run OUTPUT_FOLDER='my-output-folder' CF
 
 #### Open Taskfile Todos
 
-- TODO (GM): Implement one overarching build task?
-- TODO (GM): Implement & test Windows build
+- TODO: If you're really feeling powershell and/or cmd try scripting the build-windows task so it works from CMD and Powershell and GitBash (currently only works with Git Bash)
 - TODO (GM): Find someone with a MacOs (Samu?) to test build-linux!
-- TODO (GM): Implement a run task!
+- TODO (GM): Implement task for unit tests
 
 ### Building via Bash Script
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Short summary: Lorem ispum dolor sed...
 Since the core of the project is written in C89 only using the stdlibs, GCC is really all you need.
 However, we have introduced several tools to make our life easier:
 
-- Taskfile: Used by us for platform-independent builds. You can learn how to install Taskfile [here](https://taskfile.dev/installation/). We recommend the following options:
-  - For Windows: Install it using [Chocolatey](https://chocolatey.org/) via `choco install go-task`
+- Taskfile: Used by us for platform-independent builds. You can learn how to install Taskfile [here](https://taskfile.dev/installation/).
+However, we recommend the following ways:
+  - For Windows: Install it using [Chocolatey](https://chocolatey.org/) - everyone's favorite package manager for windows - via `choco install go-task`
   - For Linux: Install it using [Brew](https://brew.sh/) via `brew install go-task`
 
 ## Building & running

--- a/README.md
+++ b/README.md
@@ -52,10 +52,6 @@ If you're unsure how to do so a look into `compile.sh` might provide some guidan
 
 Describe some choices you made along the way here
 
-## Dependencies
-
-Deps needed for building, testing and running go here!
-
 ## TODO
 
 - Add build tool (make? ninja? cmake? taskfile? custom?)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -69,8 +69,8 @@ tasks:
     cmds:
       - mkdir -p '{{ .OUTPUT_FOLDER }}'
       - for: sources
-        cmd: gcc {{ .CFLAGS }} {{ .ITEM }} -o "$(echo {{ .ITEM }} | sed -r 's/\.c$/\.o/' | sed 's/src/{{ .OUTPUT_FOLDER }}/')" -c
-      - gcc {{ .CFLAGS }} -o '{{ .OUTPUT_FOLDER }}/minesweeper.out' $(find -type f -iwholename './{{ .OUTPUT_FOLDER }}/*.o' | xargs echo)
+        cmd: gcc {{ .CFLAGS }} "$(echo '{{ .ITEM }}' | sed -r 's/\\/\//')" -o "$(echo '{{ .ITEM }}' | sed -r 's/\\/\//' | sed -r 's/\.c$/\.o/' | sed 's/src/{{ .OUTPUT_FOLDER }}/')" -c
+      - gcc {{ .CFLAGS }} -o '{{ .OUTPUT_FOLDER }}/minesweeper.out' $(find './{{ .OUTPUT_FOLDER }}' -type f -iwholename '*.o' | xargs echo)
     generates:
       - '{{ .OUTPUT_FOLDER }}/minesweeper.out'
       - '{{ .OUTPUT_FOLDER }}/*.o'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -34,6 +34,8 @@ tasks:
       - '{{ .OUTPUT_FOLDER }}/minesweeper.out'
       - '{{ .OUTPUT_FOLDER }}/*.o'
 
+  # Currently only works when running via Git Bash
+  # If you're feeling like it, feel free to implement a powershell/cmd version as well!
   build-windows:
     platforms: [windows]
     sources:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,7 +15,7 @@ tasks:
       OUTPUT_FOLDER: '{{ default "bin" .OUTPUT_FOLDER }}'
     cmds:
       - task build-linux OUTPUT_FOLDER='{{ .OUTPUT_FOLDER }}' CFLAGS='{{ .CFLAGS }}'
-      - task build-windows OUTPUT_FOLDER='{{ .OUTPUT_FOLDER }}' CFLAGS='{{ .CFLAGS }}'
+      - task build-windows-git-bash OUTPUT_FOLDER='{{ .OUTPUT_FOLDER }}' CFLAGS='{{ .CFLAGS }}'
     silent: true
 
   build-linux:
@@ -25,6 +25,7 @@ tasks:
     vars:
       CFLAGS: '{{ default "-Wall -Wextra -Werror -ansi -pedantic" .CFLAGS }}'
       OUTPUT_FOLDER: '{{ default "bin" .OUTPUT_FOLDER }}'
+    # TODO (GM): Replace these with the compile.sh script?
     cmds:
       - mkdir -p '{{ .OUTPUT_FOLDER }}'
       - for: sources
@@ -36,7 +37,7 @@ tasks:
 
   # Currently only works when running via Git Bash
   # If you're feeling like it, feel free to implement a powershell/cmd version as well!
-  build-windows:
+  build-windows-git-bash:
     platforms: [windows]
     sources:
       - src/*.c
@@ -48,6 +49,19 @@ tasks:
       - for: sources
         cmd: gcc {{ .CFLAGS }} "$(echo '{{ .ITEM }}' | sed -r 's/\\/\//')" -o "$(echo '{{ .ITEM }}' | sed -r 's/\\/\//' | sed -r 's/\.c$/\.o/' | sed 's/src/{{ .OUTPUT_FOLDER }}/')" -c
       - gcc {{ .CFLAGS }} -o '{{ .OUTPUT_FOLDER }}/minesweeper.out' $(find . -type f -iwholename './{{ .OUTPUT_FOLDER }}/\*.o' | xargs echo)
+    generates:
+      - '{{ .OUTPUT_FOLDER }}/minesweeper.out'
+      - '{{ .OUTPUT_FOLDER }}/*.o'
+
+  build-windows-ps:
+    platforms: [windows]
+    sources:
+      - src/*.c
+    vars:
+      CFLAGS: '{{ default "-Wall -Wextra -Werror -ansi -pedantic" .CFLAGS }}'
+      OUTPUT_FOLDER: '{{ default "bin" .OUTPUT_FOLDER }}'
+    cmds:
+      - Powershell.exe ./compile.ps1
     generates:
       - '{{ .OUTPUT_FOLDER }}/minesweeper.out'
       - '{{ .OUTPUT_FOLDER }}/*.o'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,7 +15,7 @@ tasks:
       OUTPUT_FOLDER: '{{ default "bin" .OUTPUT_FOLDER }}'
     cmds:
       - task build-linux OUTPUT_FOLDER='{{ .OUTPUT_FOLDER }}' CFLAGS='{{ .CFLAGS }}'
-      - task build-windows-git-bash OUTPUT_FOLDER='{{ .OUTPUT_FOLDER }}' CFLAGS='{{ .CFLAGS }}'
+      - task build-windows OUTPUT_FOLDER='{{ .OUTPUT_FOLDER }}' CFLAGS='{{ .CFLAGS }}'
     silent: true
 
   build-linux:
@@ -35,8 +35,19 @@ tasks:
       - '{{ .OUTPUT_FOLDER }}/minesweeper.out'
       - '{{ .OUTPUT_FOLDER }}/*.o'
 
-  # Currently only works when running via Git Bash
-  # If you're feeling like it, feel free to implement a powershell/cmd version as well!
+  build-windows:
+    platforms: [windows]
+    sources:
+      - src/*.c
+    vars:
+      CFLAGS: '{{ default "-Wall -Wextra -Werror -ansi -pedantic" .CFLAGS }}'
+      OUTPUT_FOLDER: '{{ default "bin" .OUTPUT_FOLDER }}'
+    cmds:
+      - Powershell.exe ./compile.ps1
+    generates:
+      - '{{ .OUTPUT_FOLDER }}/minesweeper.out'
+      - '{{ .OUTPUT_FOLDER }}/*.o'
+
   build-windows-git-bash:
     platforms: [windows]
     sources:
@@ -49,19 +60,6 @@ tasks:
       - for: sources
         cmd: gcc {{ .CFLAGS }} "$(echo '{{ .ITEM }}' | sed -r 's/\\/\//')" -o "$(echo '{{ .ITEM }}' | sed -r 's/\\/\//' | sed -r 's/\.c$/\.o/' | sed 's/src/{{ .OUTPUT_FOLDER }}/')" -c
       - gcc {{ .CFLAGS }} -o '{{ .OUTPUT_FOLDER }}/minesweeper.out' $(find . -type f -iwholename './{{ .OUTPUT_FOLDER }}/\*.o' | xargs echo)
-    generates:
-      - '{{ .OUTPUT_FOLDER }}/minesweeper.out'
-      - '{{ .OUTPUT_FOLDER }}/*.o'
-
-  build-windows-ps:
-    platforms: [windows]
-    sources:
-      - src/*.c
-    vars:
-      CFLAGS: '{{ default "-Wall -Wextra -Werror -ansi -pedantic" .CFLAGS }}'
-      OUTPUT_FOLDER: '{{ default "bin" .OUTPUT_FOLDER }}'
-    cmds:
-      - Powershell.exe ./compile.ps1
     generates:
       - '{{ .OUTPUT_FOLDER }}/minesweeper.out'
       - '{{ .OUTPUT_FOLDER }}/*.o'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -43,11 +43,9 @@ tasks:
       OUTPUT_FOLDER: '{{ default "bin" .OUTPUT_FOLDER }}'
     cmds:
       - mkdir -p '{{ .OUTPUT_FOLDER }}'
-        # TODO (GM): Implement for windows!
-        # - for: sources
-        #   cmd: gcc {{ .CFLAGS }} {{ .ITEM }} -o "$(echo {{ .ITEM }} | sed -r 's/\.c$/\.o/' | sed 's/src/{{ .OUTPUT_FOLDER }}/')" -c
-        # - gcc {{ .CFLAGS }} -o '{{ .OUTPUT_FOLDER }}/minesweeper.out' $(find -type f -iwholename './{{ .OUTPUT_FOLDER }}/*.o' | xargs echo)
-      - echo 'Windows-Build is currently not implemented!'
+      - for: sources
+        cmd: gcc {{ .CFLAGS }} "$(echo '{{ .ITEM }}' | sed -r 's/\\/\//')" -o "$(echo '{{ .ITEM }}' | sed -r 's/\\/\//' | sed -r 's/\.c$/\.o/' | sed 's/src/{{ .OUTPUT_FOLDER }}/')" -c
+      - gcc {{ .CFLAGS }} -o '{{ .OUTPUT_FOLDER }}/minesweeper.out' $(find . -type f -iwholename './{{ .OUTPUT_FOLDER }}/\*.o' | xargs echo)
     generates:
       - '{{ .OUTPUT_FOLDER }}/minesweeper.out'
       - '{{ .OUTPUT_FOLDER }}/*.o'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -44,23 +44,8 @@ tasks:
       - '{{ .OUTPUT_FOLDER }}/minesweeper.out'
       - '{{ .OUTPUT_FOLDER }}/*.o'
 
-  build-windows-git-bash:
-    platforms: [windows]
-    sources:
-      - src/*.c
-    vars:
-      CFLAGS: '{{ default "-Wall -Wextra -Werror -ansi -pedantic" .CFLAGS }}'
-      OUTPUT_FOLDER: '{{ default "bin" .OUTPUT_FOLDER }}'
-    cmds:
-      - mkdir -p '{{ .OUTPUT_FOLDER }}'
-      - for: sources
-        cmd: gcc {{ .CFLAGS }} "$(echo '{{ .ITEM }}' | sed -r 's/\\/\//')" -o "$(echo '{{ .ITEM }}' | sed -r 's/\\/\//' | sed -r 's/\.c$/\.o/' | sed 's/src/{{ .OUTPUT_FOLDER }}/')" -c
-      - gcc {{ .CFLAGS }} -o '{{ .OUTPUT_FOLDER }}/minesweeper.out' $(find . -type f -iwholename './{{ .OUTPUT_FOLDER }}/\*.o' | xargs echo)
-    generates:
-      - '{{ .OUTPUT_FOLDER }}/minesweeper.out'
-      - '{{ .OUTPUT_FOLDER }}/*.o'
-
   build-shell:
+    # No platform restriction, might also be run on windows under e.g. git bash
     sources:
       - src/*.c
     vars:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -25,12 +25,8 @@ tasks:
     vars:
       CFLAGS: '{{ default "-Wall -Wextra -Werror -ansi -pedantic" .CFLAGS }}'
       OUTPUT_FOLDER: '{{ default "bin" .OUTPUT_FOLDER }}'
-    # TODO (GM): Replace these with the compile.sh script?
     cmds:
-      - mkdir -p '{{ .OUTPUT_FOLDER }}'
-      - for: sources
-        cmd: gcc {{ .CFLAGS }} {{ .ITEM }} -o "$(echo {{ .ITEM }} | sed -r 's/\.c$/\.o/' | sed 's/src/{{ .OUTPUT_FOLDER }}/')" -c
-      - gcc {{ .CFLAGS }} -o '{{ .OUTPUT_FOLDER }}/minesweeper.out' $(find -type f -iwholename './{{ .OUTPUT_FOLDER }}/*.o' | xargs echo)
+      - task build-shell
     generates:
       - '{{ .OUTPUT_FOLDER }}/minesweeper.out'
       - '{{ .OUTPUT_FOLDER }}/*.o'
@@ -60,6 +56,21 @@ tasks:
       - for: sources
         cmd: gcc {{ .CFLAGS }} "$(echo '{{ .ITEM }}' | sed -r 's/\\/\//')" -o "$(echo '{{ .ITEM }}' | sed -r 's/\\/\//' | sed -r 's/\.c$/\.o/' | sed 's/src/{{ .OUTPUT_FOLDER }}/')" -c
       - gcc {{ .CFLAGS }} -o '{{ .OUTPUT_FOLDER }}/minesweeper.out' $(find . -type f -iwholename './{{ .OUTPUT_FOLDER }}/\*.o' | xargs echo)
+    generates:
+      - '{{ .OUTPUT_FOLDER }}/minesweeper.out'
+      - '{{ .OUTPUT_FOLDER }}/*.o'
+
+  build-shell:
+    sources:
+      - src/*.c
+    vars:
+      CFLAGS: '{{ default "-Wall -Wextra -Werror -ansi -pedantic" .CFLAGS }}'
+      OUTPUT_FOLDER: '{{ default "bin" .OUTPUT_FOLDER }}'
+    cmds:
+      - mkdir -p '{{ .OUTPUT_FOLDER }}'
+      - for: sources
+        cmd: gcc {{ .CFLAGS }} {{ .ITEM }} -o "$(echo {{ .ITEM }} | sed -r 's/\.c$/\.o/' | sed 's/src/{{ .OUTPUT_FOLDER }}/')" -c
+      - gcc {{ .CFLAGS }} -o '{{ .OUTPUT_FOLDER }}/minesweeper.out' $(find -type f -iwholename './{{ .OUTPUT_FOLDER }}/*.o' | xargs echo)
     generates:
       - '{{ .OUTPUT_FOLDER }}/minesweeper.out'
       - '{{ .OUTPUT_FOLDER }}/*.o'

--- a/compile.ps1
+++ b/compile.ps1
@@ -1,5 +1,4 @@
-# Replace this with calling compile.sh?
 $proc = Start-Process -NoNewWindow -PassThru -FilePath "$env:Programfiles\Git\git-bash.exe" `
-	-ArgumentList "-c", "'task build-windows-git-bash; sleep 3s'"
+	-ArgumentList "-c", "'task build-shell; sleep 3s'"
 
 $proc.WaitForExit()

--- a/compile.ps1
+++ b/compile.ps1
@@ -1,4 +1,11 @@
+$tmpfile = New-TemporaryFile | Select -ExpandProperty FullName
+$tmpfile_lin = $tmpfile -replace 'C:', '/c' -replace '\\', '/'
+
 $proc = Start-Process -NoNewWindow -PassThru -FilePath "$env:Programfiles\Git\git-bash.exe" `
-	-ArgumentList "-c", "'task build-shell; sleep 3s'"
+	-ArgumentList "-c", "'task build-shell > $tmpfile_lin 2>&1'"
 
 $proc.WaitForExit()
+
+echo "Build output can be found at $tmpfile"
+echo "--- BUILD LOG OUTPUT ---"
+cat $tmpfile

--- a/compile.ps1
+++ b/compile.ps1
@@ -1,5 +1,5 @@
 # Replace this with calling compile.sh?
 $proc = Start-Process -NoNewWindow -PassThru -FilePath "$env:Programfiles\Git\git-bash.exe" `
-	-ArgumentList "-c", "'task build; sleep 3s'"
+	-ArgumentList "-c", "'task build-windows-git-bash; sleep 3s'"
 
 $proc.WaitForExit()

--- a/compile.ps1
+++ b/compile.ps1
@@ -1,0 +1,5 @@
+# Replace this with calling compile.sh?
+$proc = Start-Process -NoNewWindow -PassThru -FilePath "$env:Programfiles\Git\git-bash.exe" `
+	-ArgumentList "-c", "'task build; sleep 3s'"
+
+$proc.WaitForExit()


### PR DESCRIPTION
Implemented an windows build task.

How it works:
[Install Taskfile](https://taskfile.dev/installation/). Note that Taskfile can also be installed via [everyone's favorite package manager for windows](https://chocolatey.org/) with `choco install go-task`.
With Taskfile installed navigate to the root directory of this project.
Then use `task build` to compile the project or `task run` to compile & run the project.

This should work on linux (on a shell of your choice), as well as on windows: On Git Bash, CMD, as well as PowerShell.
Note that for windows this requires `Git Bash`, but since this is a git project, that shouldn't be an issue :)

This hopefully saves us some time in the future, since `task build` is quite a bit shorter than always compiling everything.

I tested it on my windows VM, but please feel free to test it as well. Please submit Feedback if you have some!

All of my instruction above should also be reflected in the `README.md` and if they are not, please submit a comment! Documentation is important :)